### PR TITLE
`jspm install` fails with jspm v0.16.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sample application which demonstrates using [angular-powerbi](https://github.com
   
   `jspm install`
   
-  If you don't have jspm installed, you can install it locally or globaly using `npm install -g jspm`
+  If you don't have jspm installed, you can install it locally or globaly using `npm install -g jspm@0.17.0-beta.15` (`PowerBI-Angular will fail to install with jspm v0.16.x)
   
 3. Serve the files from the root of the repository:
 


### PR DESCRIPTION
Error when running `jspm install` with jspm v0.16.36, npm v3.9.3, node v6.21. Tried with jspm 0.16.34 and others downwards...

```
warn Running jspm globally, it is advisable to locally install jspm via npm install jspm --save-dev.
     Looking up npm:angular-powerbi
     Looking up github:angular/bower-angular

warn Using local override for github:angular/bower-angular@1.5.7
     Looking up github:twbs/bootstrap

warn Using local override for github:twbs/bootstrap@3.3.6
     Updating registry cache...
     Looking up github:angular-ui/ui-router

warn Using local override for github:angular-ui/ui-router@0.2.18
     Looking up github:frankwallis/plugin-typescript
     Downloading npm:angular-powerbi@1.0.0-beta.3

warn Error on processPackageConfig
     Package.json dependency os set to github:jspm/nodelibs-os@^0.2.0-alpha, which is not a valid dependency format for npm.
     It's advisable to publish jspm-style packages to GitHub or another registry so conventions are clear.

warn Error processing package config for npm:angular-powerbi.
     Looking up npm:typescript

warn Using local override for npm:typescript@1.8.10

err  Error processing package config for npm:angular-powerbi.
```
